### PR TITLE
Fix up Docushare references

### DIFF
--- a/body.tex
+++ b/body.tex
@@ -21,7 +21,7 @@ It provides a customizable and easily-extensible set of tools to:
 \section{The Faro Framework} \label{sec:faro}
 
 Two main components form the basis of the \faro framework: a collection of \texttt{Task}s that measure specific metric values and a set of base classes that handle data i/o for various types of input data units corresponding to the granularity of metric computation, e.g., per-detector, per-visit, per-patch, per-tract.
-\faro builds upon much of the existing infrastructure of the LSST Science Pipelines, in particular, the ``Generation 3'' middleware, including the Data Butler and Task Framework\cite{dmtn-229}, and the LSST verification framework\cite{SQR-019}.
+\faro builds upon much of the existing infrastructure of the LSST Science Pipelines, in particular, the ``Generation 3'' middleware, including the Data Butler and Task Framework\cite{SPIE-12189-40}, and the LSST verification framework\cite{SQR-019}.
 The LSST Data Butler (hereafter the ``Butler'') provides an abstracted data access interface that is used to read and write data without knowing the details of file formats or locations.
 The Butler organizes data, both raw and processed, into data repositories.
 A \texttt{Task} is a reusable unit of code in the LSST science pipelines infrastructure used to process data.

--- a/local.bib
+++ b/local.bib
@@ -17,21 +17,24 @@
   adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2021arXiv211115030O,
-       author = {{O'Mullane}, William and {Economou}, Frossie and {Huang}, Flora and {Speck}, Dan and {Chiang}, Hsin-Fang and {Graham}, Melissa L. and {Allbery}, Russ and {Banek}, Christine and {Sick}, Jonathan and {Thornton}, Adam J. and {Masciarelli}, Jess and {Lim}, Kian-Tat and {Mueller}, Fritz and {Padolski}, Sergey and {Jenness}, Tim and {Krughoff}, K. Simon and {Gower}, Michelle and {Guy}, Leanne P. and {Dubois-Felsmann}, Gregory P.},
-        title = "{Rubin Science Platform on Google: the story so far}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2021,
-        month = nov,
-          eid = {arXiv:2111.15030},
-        pages = {arXiv:2111.15030},
-archivePrefix = {arXiv},
-       eprint = {2111.15030},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2021arXiv211115030O},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@inproceedings{2021arXiv211115030O,
+  author        = {{O'Mullane}, William and {Economou}, Frossie and {Huang}, Flora and {Speck}, Dan and {Chiang}, Hsin-Fang and {Graham}, Melissa L. and {Allbery}, Russ and {Banek}, Christine and {Sick}, Jonathan and {Thornton}, Adam J. and {Masciarelli}, Jess and {Lim}, Kian-Tat and {Mueller}, Fritz and {Padolski}, Sergey and {Jenness}, Tim and {Krughoff}, K. Simon and {Gower}, Michelle and {Guy}, Leanne P. and {Dubois-Felsmann}, Gregory P.},
+  title         = {{Rubin Science Platform on Google: the story so far}},
+  booktitle     = {Astronomical Data Analysis Software and Systems XXXI},
+  series        = {ASP Conf.\ Ser.},
+  volume        = {in press},
+  keywords      = {Astrophysics - Instrumentation and Methods for Astrophysics},
+  year          = 2021,
+  month         = nov,
+  eid           = {arXiv:2111.15030},
+  pages         = {arXiv:2111.15030},
+  archiveprefix = {arXiv},
+  eprint        = {2111.15030},
+  primaryclass  = {astro-ph.IM},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/2021arXiv211115030O},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
 @inproceedings{10.1117/12.2561112,
 author = {Patrick Ingraham and Andy W. Clements and Tiago Ribeiro and Michael A. Reuter and Merlin Fisher-Levine and Joshua Hoblitt and Robert H. Lupton and Sandrine Thomas and Christopher W. Stubbs and Kirk T. Arndt and Nick Callahan and Charles F. Claver and Franco Colleoni and Luis Corral and Peter Doherty and Frossie Economou and Angel Fausti Neto and Tim Jenness and Htut Khine and K. Simon Krughoff and Nicholas Mondrik and Felipe Menanteau and David J. Mills and William O'Mullane and Kevin A Reil and Mario Rivera and Brian Stalder and Jacques Sebag and Ian Shipsey and Roberto Tighe and Adam J. Thornton and Andres Villalobos and Oliver Wiecha},
 title = {{Vera C. Rubin Observatory auxiliary telescope commissioning as a control system pathfinder}},

--- a/local.bib
+++ b/local.bib
@@ -46,3 +46,13 @@ year = {2020},
 doi = {10.1117/12.2561112},
 URL = {https://doi.org/10.1117/12.2561112}
 }
+
+@inproceedings{SPIE-12189-40,
+author = {Tim Jenness and James F. Bosch and Andrei Salnikov and Nate B. Lust and Nathan M. Pease and Michelle Gower and Mikolaj Kowalik and Gregory P. Dubois-Felsmann and Kian-Tat Lim and Fritz Mueller and Pim Schellart},
+title = {{The Vera C. Rubin Observatory Data Butler and Pipeline Execution System}},
+series = {Proc.\ SPIE},
+year = 2022,
+booktitle = {Software and Cyberinfrastructure for Astronomy VII},
+volume = 12189,
+pages = {12189-40},
+}

--- a/spiebib.bst
+++ b/spiebib.bst
@@ -7,11 +7,11 @@
 % and publisher/address fields reversed.
 %     July 3, 1995  (kmh)  Ken Hanson
 % In "inproceedings" allow 'journal' and avoid complaint
-% if 'booktitle' missing. 
+% if 'booktitle' missing.
 %     Dec. 10, 1997  (kmh)  Ken Hanson
 % In "inproceedings", 'series' produces the same output as previous 'journal'
 %     May 14, 2001 (hto)  Hwa-Tung Ong
-% Put 'volume' in bold after 'series' in "collection", "incollection", 
+% Put 'volume' in bold after 'series' in "collection", "incollection",
 %  and "inproceedings".
 %     Aug. 29, 2001  (kmh)  Ken Hanson
 %  insert ~ in volume bold line to avoid line break between journal and volume
@@ -53,6 +53,8 @@ ENTRY
     type
     volume
     year
+    handle
+    url
   }
   {}
   { label }
@@ -227,6 +229,18 @@ FUNCTION {bold}                   %% kmh - new function like emphasize
 
 INTEGERS { nameptr namesleft numnames }
 
+FUNCTION {format.url}
+{
+  url empty$
+    { handle empty$
+      'skip$
+      { "\url{https://ls.st/" handle * "}" * output }
+    if$
+    }
+    { "\url{" url * "}" * output }
+  if$
+}
+
 FUNCTION {format.names}
 { 's :=
   #1 'nameptr :=
@@ -326,9 +340,9 @@ FUNCTION {format.date}
       if$
     }
     { month empty$
-  { write$ " (" year * ")" *  
+  { write$ " (" year * ")" *
     after.block 'output.state := }  %kmh date in parens
-	{ write$ " (" month * " " * year * ")" * 
+	{ write$ " (" month * " " * year * ")" *
 	  after.block 'output.state := }  %kmh date in parens
       if$
     }
@@ -462,7 +476,7 @@ FUNCTION {format.series.volume.number}   %% hto01 - similar to format.journal.vo
     { "" }                  %% hto01 - no warning of empty title
     { series emphasize }
   if$
-  volume empty$ 
+  volume empty$
     { "" *}                   %% kmh - no warning if no volume
     { " " * volume bold *}    %% kmh - make volume bold
 %%    { "vol.~" volume * }
@@ -647,14 +661,14 @@ FUNCTION {format.incoll.inproc.crossref}
 	      crossref * warning$
 	      ""
 	    }
-	    { " in {\em " booktitle * "\/}" * }   
+	    { " in {\em " booktitle * "\/}" * }
 %% kmh - add space before 'in'
 	  if$
 	}
 	{ " in " key * }   %% kmh - add space before 'in'
       if$
     }
-    { " in " format.crossref.editor * }   
+    { " in " format.crossref.editor * }
 %% kmh - add space before 'in'
   if$
   " \cite{" * crossref * "}" *
@@ -668,7 +682,7 @@ FUNCTION {article}
   crossref missing$
     { format.journal.volume.number output
       format.pages output
-      format.date 
+      format.date
     }
     { format.article.crossref output.nonnull
       format.pages output
@@ -704,7 +718,7 @@ FUNCTION {book}
     }
   if$
   format.edition output
-  format.date 
+  format.date
   new.block
   note output
   fin.entry
@@ -809,7 +823,7 @@ FUNCTION {inproceedings}
 %% moved below    format.paddress output
           format.pages output
 	 }
-         {format.journal.volume.number output  
+         {format.journal.volume.number output
 
 %% add jour., vol.,and number
           format.pages output
@@ -897,6 +911,21 @@ FUNCTION {misc}
   format.date
   new.block
   note output
+  fin.entry
+  empty.misc.check
+}
+
+FUNCTION {docushare}
+{ output.bibitem
+  format.authors output
+  format.title "title" output.check
+  howpublished output
+  note output
+  handle output
+  blank.sep
+  format.url
+  format.date
+  new.block
   fin.entry
   empty.misc.check
 }


### PR DESCRIPTION
@leannep this fixes references a bit. The update of the lsst-texmf submodule is needed to pull in some fixes I made to tech note bib entries when I was working on DMTN-229.

Two more general comments about SPIE papers:

* SPIE does not use backrefs from references back to a page number.
* There should usually not be an acronyms section, acronyms should be expanded on first use in the main text.